### PR TITLE
fix: turn off autocorrect

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
           <span id="sort-template" class="option">{label}</span>
         </div>
         <p class="search-container">
-          <input type="search" id="search-input" placeholder="Search..." />
+          <input type="search" id="search-input" placeholder="Search..." autocorrect="off" />
           <span class="search-tip"
             >(tip: you can type anywhere to start searching)</span
           >


### PR DESCRIPTION
We forgot to turn off autocorrect.

Should we turn off autocomplete, too? It's kinda annoying.