### PR TITLE
Use app.excalideck.com domain for Excalideck in the app whitelist

### DIFF
--- a/script.js
+++ b/script.js
@@ -139,7 +139,7 @@ const sortBy = {
 const APP_NAMES = {
   "Excalidraw+": "https://app.excalidraw.com",
   Excalidraw: "https://excalidraw.com",
-  Excalideck: "https://excalideck.com",
+  Excalideck: "https://app.excalideck.com",
 };
 
 let appName = "";


### PR DESCRIPTION
`app.excalideck.com` is the domain users usually work from.