### PR TITLE
Change drwn.io domain

### DIFF
--- a/authors.json
+++ b/authors.json
@@ -108,8 +108,8 @@
     "id": "599mSI9ZxOX"
   },
   {
-    "name": "drwn.io",
-    "website": "https://drwn.io/",
+    "name": "drwnio.polyrand.net",
+    "website": "https://drwnio.polyrand.net/",
     "created": "2021-01-25T00:00:00.000Z",
     "libraries": ["7JW0nUyIW2R", "55rgwmkZSXc"],
     "id": "2PoybfnrYfw"

--- a/libraries.json
+++ b/libraries.json
@@ -409,8 +409,8 @@
     "description": "Software architecture logos: archive, database, docker, JSON, Kubernetes, load balancer, Postgres, Redis, Nginx, RabbitMQ, server, chip, reverse proxy, and more.",
     "authors": [
       {
-        "name": "drwn.io",
-        "url": "https://drwn.io/"
+        "name": "drwnio.polyrand.net",
+        "url": "https://drwnio.polyrand.net/"
       }
     ],
     "source": "drwnio/drwnio.excalidrawlib",
@@ -441,8 +441,8 @@
     "description": "Drawings representing emotions or whatever you want. Perfect to add some fun or stories to your diagrams.",
     "authors": [
       {
-        "name": "drwn.io",
-        "url": "https://drwn.io/"
+        "name": "drwnio.polyrand.net",
+        "url": "https://drwnio.polyrand.net/"
       }
     ],
     "source": "drwnio/storytelling.excalidrawlib",


### PR DESCRIPTION
As described in #1334, I am the owner of the `drwn.io` domain.

I may not own this domain in the future, and I would like to avoid keeping a link that could point to somewhere else without my control.

To prove that I own the new domain added in this PR, I have set a redirect from the previous domain to the new one (`https://drwnio.polyrand.net/`). This can be verified by visiting the removed domain, which should automatically redirect to the new one.


Closes #1334

