### PR TITLE
fix: prevent SVG color changes in documents by unsetting inherited styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -272,3 +272,10 @@ input:focus {
   max-width: 90%;
   border: 1px solid var(--oc-gray-5);
 }
+
+/* Prevent SVG color override in documents */
+svg {
+  color: unset !important;
+  fill: unset !important;
+  stroke: unset !important;
+}


### PR DESCRIPTION
## 🛠️ Fix: Preserve Original SVG Colors in Documents

**Fixes #1304**

This pull request addresses [#1304](https://github.com/excalidraw/excalidraw-libraries/issues/1304), where SVG images rendered inside documents (`![[imagename]]`) were displaying with altered colors due to inherited styles.

### 🔧 Changes Made:
Added the following CSS to `style.css` to prevent SVG elements from inheriting unwanted styles:

```css
/* Prevent SVG color override in documents */
svg {
  color: unset !important;
  fill: unset !important;
  stroke: unset !important;
}
